### PR TITLE
refactor: remove repeated magic strings

### DIFF
--- a/src/main/java/com/gildedrose/GildedRose.java
+++ b/src/main/java/com/gildedrose/GildedRose.java
@@ -1,6 +1,10 @@
 package com.gildedrose;
 
 class GildedRose {
+    private static final String AGED_BRIE = "Aged Brie";
+    private static final String BACKSTAGE_PASSES = "Backstage passes to a TAFKAL80ETC concert";
+    private static final String SULFURAS = "Sulfuras, Hand of Ragnaros";
+    
     Item[] items;
 
     public GildedRose(Item[] items) {
@@ -9,10 +13,10 @@ class GildedRose {
 
     public void updateQuality() {
         for (int i = 0; i < items.length; i++) {
-            if (!items[i].name.equals("Aged Brie")
-                    && !items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+            if (!items[i].name.equals(AGED_BRIE)
+                    && !items[i].name.equals(BACKSTAGE_PASSES)) {
                 if (items[i].quality > 0) {
-                    if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
+                    if (!items[i].name.equals(SULFURAS)) {
                         items[i].quality = items[i].quality - 1;
                     }
                 }
@@ -20,7 +24,7 @@ class GildedRose {
                 if (items[i].quality < 50) {
                     items[i].quality = items[i].quality + 1;
 
-                    if (items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                    if (items[i].name.equals(BACKSTAGE_PASSES)) {
                         if (items[i].sellIn < 11) {
                             if (items[i].quality < 50) {
                                 items[i].quality = items[i].quality + 1;
@@ -36,15 +40,15 @@ class GildedRose {
                 }
             }
 
-            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
+            if (!items[i].name.equals(SULFURAS)) {
                 items[i].sellIn = items[i].sellIn - 1;
             }
 
             if (items[i].sellIn < 0) {
-                if (!items[i].name.equals("Aged Brie")) {
-                    if (!items[i].name.equals("Backstage passes to a TAFKAL80ETC concert")) {
+                if (!items[i].name.equals(AGED_BRIE)) {
+                    if (!items[i].name.equals(BACKSTAGE_PASSES)) {
                         if (items[i].quality > 0) {
-                            if (!items[i].name.equals("Sulfuras, Hand of Ragnaros")) {
+                            if (!items[i].name.equals(SULFURAS)) {
                                 items[i].quality = items[i].quality - 1;
                             }
                         }


### PR DESCRIPTION
Moved magic strings to top of class. Reducing risk of typos, and eliminating duplication.